### PR TITLE
Use current release version of dbus-java.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,10 +47,15 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>com.github.hypfvieh</groupId>
-      <artifactId>dbus-java</artifactId>
-      <version>2.7.2</version>
+	<dependency>
+	  <groupId>com.github.hypfvieh</groupId>
+	  <artifactId>dbus-java</artifactId>
+	  <version>3.2.1</version>
+	</dependency>
+	<dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.4.0-b180830.0359</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/de/thjom/java/systemd/AbstractAdapter.java
+++ b/src/main/java/de/thjom/java/systemd/AbstractAdapter.java
@@ -15,10 +15,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.freedesktop.DBus.Properties.PropertiesChanged;
-import org.freedesktop.dbus.DBusSigHandler;
-import org.freedesktop.dbus.DBusSignal;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusSigHandler;
+import org.freedesktop.dbus.interfaces.Properties.PropertiesChanged;
+import org.freedesktop.dbus.messages.DBusSignal;
 
 abstract class AbstractAdapter {
 

--- a/src/main/java/de/thjom/java/systemd/ForwardingHandler.java
+++ b/src/main/java/de/thjom/java/systemd/ForwardingHandler.java
@@ -13,8 +13,8 @@ package de.thjom.java.systemd;
 
 import java.util.Objects;
 
-import org.freedesktop.dbus.DBusSigHandler;
-import org.freedesktop.dbus.DBusSignal;
+import org.freedesktop.dbus.interfaces.DBusSigHandler;
+import org.freedesktop.dbus.messages.DBusSignal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/de/thjom/java/systemd/InterfaceAdapter.java
+++ b/src/main/java/de/thjom/java/systemd/InterfaceAdapter.java
@@ -16,11 +16,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.freedesktop.dbus.DBusConnection;
-import org.freedesktop.dbus.DBusInterface;
-import org.freedesktop.dbus.DBusSigHandler;
-import org.freedesktop.dbus.DBusSignal;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.interfaces.DBusSigHandler;
+import org.freedesktop.dbus.messages.DBusSignal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/de/thjom/java/systemd/Manager.java
+++ b/src/main/java/de/thjom/java/systemd/Manager.java
@@ -15,9 +15,10 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.DBus.Introspectable;
-import org.freedesktop.dbus.DBusConnection;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.Introspectable;
 
 import de.thjom.java.systemd.Unit.Mode;
 import de.thjom.java.systemd.Unit.Who;
@@ -180,7 +181,7 @@ public class Manager extends InterfaceAdapter {
         return getInterface().getDefaultTarget();
     }
 
-    public org.freedesktop.dbus.Path getUnitByPID(final int pid) {
+    public DBusPath getUnitByPID(final int pid) {
         return getInterface().getUnitByPID(pid);
     }
 
@@ -208,7 +209,7 @@ public class Manager extends InterfaceAdapter {
         return getInterface().listUnits();
     }
 
-    public org.freedesktop.dbus.Path loadUnit(final String name) {
+    public DBusPath loadUnit(final String name) {
         return getInterface().loadUnit(name);
     }
 
@@ -240,27 +241,27 @@ public class Manager extends InterfaceAdapter {
         getInterface().reload();
     }
 
-    public org.freedesktop.dbus.Path reloadOrRestartUnit(final String name, final Mode mode) {
+    public DBusPath reloadOrRestartUnit(final String name, final Mode mode) {
         return reloadOrRestartUnit(name, mode.getValue());
     }
 
-    public org.freedesktop.dbus.Path reloadOrRestartUnit(final String name, final String mode) {
+    public DBusPath reloadOrRestartUnit(final String name, final String mode) {
         return getInterface().reloadOrRestartUnit(name, mode);
     }
 
-    public org.freedesktop.dbus.Path reloadOrTryRestartUnit(final String name, final Mode mode) {
+    public DBusPath reloadOrTryRestartUnit(final String name, final Mode mode) {
         return reloadOrTryRestartUnit(name, mode.getValue());
     }
 
-    public org.freedesktop.dbus.Path reloadOrTryRestartUnit(final String name, final String mode) {
+    public DBusPath reloadOrTryRestartUnit(final String name, final String mode) {
         return getInterface().reloadOrTryRestartUnit(name, mode);
     }
 
-    public org.freedesktop.dbus.Path reloadUnit(final String name, final Mode mode) {
+    public DBusPath reloadUnit(final String name, final Mode mode) {
         return reloadUnit(name, mode.getValue());
     }
 
-    public org.freedesktop.dbus.Path reloadUnit(final String name, final String mode) {
+    public DBusPath reloadUnit(final String name, final String mode) {
         return getInterface().reloadUnit(name, mode);
     }
 
@@ -272,15 +273,15 @@ public class Manager extends InterfaceAdapter {
         getInterface().resetFailedUnit(name);
     }
 
-    public org.freedesktop.dbus.Path restartUnit(final String name, final Mode mode) {
+    public DBusPath restartUnit(final String name, final Mode mode) {
         return restartUnit(name, mode.getValue());
     }
 
-    public org.freedesktop.dbus.Path restartUnit(final String name, final String mode) {
+    public DBusPath restartUnit(final String name, final String mode) {
         return getInterface().restartUnit(name, mode);
     }
 
-    public org.freedesktop.dbus.Path startUnit(final String name, final Mode mode) {
+    public DBusPath startUnit(final String name, final Mode mode) {
         return startUnit(name, mode.getValue());
     }
 
@@ -292,15 +293,15 @@ public class Manager extends InterfaceAdapter {
         getInterface().setExitCode(value);
     }
 
-    public org.freedesktop.dbus.Path startUnit(final String name, final String mode) {
+    public DBusPath startUnit(final String name, final String mode) {
         return getInterface().startUnit(name, mode);
     }
 
-    public org.freedesktop.dbus.Path stopUnit(final String name, final Mode mode) {
+    public DBusPath stopUnit(final String name, final Mode mode) {
         return stopUnit(name, mode.getValue());
     }
 
-    public org.freedesktop.dbus.Path stopUnit(final String name, final String mode) {
+    public DBusPath stopUnit(final String name, final String mode) {
         return getInterface().stopUnit(name, mode);
     }
 
@@ -316,11 +317,11 @@ public class Manager extends InterfaceAdapter {
         getInterface().switchRoot(newRoot, init);
     }
 
-    public org.freedesktop.dbus.Path tryRestartUnit(final String name, final Mode mode) {
+    public DBusPath tryRestartUnit(final String name, final Mode mode) {
         return tryRestartUnit(name, mode.getValue());
     }
 
-    public org.freedesktop.dbus.Path tryRestartUnit(final String name, final String mode) {
+    public DBusPath tryRestartUnit(final String name, final String mode) {
         return getInterface().tryRestartUnit(name, mode);
     }
 

--- a/src/main/java/de/thjom/java/systemd/Properties.java
+++ b/src/main/java/de/thjom/java/systemd/Properties.java
@@ -14,10 +14,10 @@ package de.thjom.java.systemd;
 import java.math.BigInteger;
 import java.util.Vector;
 
-import org.freedesktop.dbus.DBusConnection;
-import org.freedesktop.dbus.UInt64;
-import org.freedesktop.dbus.Variant;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.types.UInt64;
+import org.freedesktop.dbus.types.Variant;
 
 import de.thjom.java.systemd.interfaces.PropertyInterface;
 

--- a/src/main/java/de/thjom/java/systemd/Signal.java
+++ b/src/main/java/de/thjom/java/systemd/Signal.java
@@ -11,8 +11,8 @@
 
 package de.thjom.java.systemd;
 
-import org.freedesktop.dbus.DBusSignal;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.messages.DBusSignal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/de/thjom/java/systemd/SignalConsumer.java
+++ b/src/main/java/de/thjom/java/systemd/SignalConsumer.java
@@ -15,8 +15,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.freedesktop.dbus.DBusSigHandler;
-import org.freedesktop.dbus.DBusSignal;
+import org.freedesktop.dbus.interfaces.DBusSigHandler;
+import org.freedesktop.dbus.messages.DBusSignal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/de/thjom/java/systemd/SignalSequencer.java
+++ b/src/main/java/de/thjom/java/systemd/SignalSequencer.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import org.freedesktop.dbus.DBusSignal;
+import org.freedesktop.dbus.messages.DBusSignal;
 
 final class SignalSequencer<T extends DBusSignal> {
 

--- a/src/main/java/de/thjom/java/systemd/Systemd.java
+++ b/src/main/java/de/thjom/java/systemd/Systemd.java
@@ -19,7 +19,8 @@ import java.util.regex.Pattern;
 
 import javax.xml.bind.DatatypeConverter;
 
-import org.freedesktop.dbus.DBusConnection;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.connections.impl.DBusConnection.DBusBusType;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.NotConnected;
 import org.slf4j.Logger;
@@ -29,16 +30,16 @@ public final class Systemd {
 
     public enum InstanceType {
 
-        SYSTEM(DBusConnection.SYSTEM),
-        USER(DBusConnection.SESSION);
+        SYSTEM(DBusConnection.DBusBusType.SYSTEM),
+        USER(DBusConnection.DBusBusType.SESSION);
 
-        private final int index;
+        private final DBusConnection.DBusBusType index;
 
-        private InstanceType(final int index) {
+        private InstanceType(DBusConnection.DBusBusType index) {
             this.index = index;
         }
 
-        public final int getIndex() {
+        public final DBusConnection.DBusBusType getIndex() {
             return index;
         }
 
@@ -104,19 +105,19 @@ public final class Systemd {
     }
 
     public static Systemd get(final InstanceType instanceType) throws DBusException {
-        final int index = instanceType.getIndex();
+        final DBusBusType index = instanceType.getIndex();
 
         Systemd instance;
 
         synchronized (instances) {
-            if (instances[index] == null) {
+            if (instances[index.ordinal()] == null) {
                 instance = new Systemd(instanceType);
                 instance.open();
 
-                instances[index] = instance;
+                instances[index.ordinal()] = instance;
             }
             else {
-                instance = instances[index];
+                instance = instances[index.ordinal()];
             }
         }
 
@@ -132,10 +133,10 @@ public final class Systemd {
     }
 
     public static void disconnect(final InstanceType instanceType, final long retardationTime) {
-        final int index = instanceType.getIndex();
+        final DBusBusType index = instanceType.getIndex();
 
         synchronized (instances) {
-            Systemd instance = instances[index];
+            Systemd instance = instances[index.ordinal()];
 
             if (instance != null) {
                 try {
@@ -148,7 +149,7 @@ public final class Systemd {
                 }
             }
 
-            instances[index] = null;
+            instances[index.ordinal()] = null;
         }
     }
 

--- a/src/main/java/de/thjom/java/systemd/Unit.java
+++ b/src/main/java/de/thjom/java/systemd/Unit.java
@@ -20,13 +20,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
-import org.freedesktop.DBus.Introspectable;
-import org.freedesktop.DBus.Properties.PropertiesChanged;
-import org.freedesktop.dbus.DBusSigHandler;
-import org.freedesktop.dbus.DBusSignal;
-import org.freedesktop.dbus.Path;
-import org.freedesktop.dbus.Variant;
+import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusSigHandler;
+import org.freedesktop.dbus.interfaces.Introspectable;
+import org.freedesktop.dbus.interfaces.Properties.PropertiesChanged;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.freedesktop.dbus.types.Variant;
 
 import de.thjom.java.systemd.interfaces.PropertyInterface;
 import de.thjom.java.systemd.interfaces.UnitInterface;
@@ -258,7 +258,7 @@ public abstract class Unit extends InterfaceAdapter implements UnitStateNotifier
     @Override
     protected SignalConsumer<PropertiesChanged> createStateConsumer() {
         return new SignalConsumer<>(s -> {
-            Map<String, Variant<?>> properties = s.changedProperties;
+            Map<String, Variant<?>> properties = s.getPropertiesChanged();
 
             if (properties.containsKey(ACTIVE_STATE) || properties.containsKey(LOAD_STATE) || properties.containsKey(SUB_STATE)) {
                 synchronized (unitStateListeners) {
@@ -274,59 +274,59 @@ public abstract class Unit extends InterfaceAdapter implements UnitStateNotifier
         return intro.Introspect();
     }
 
-    public Path start(final Mode mode) {
+    public DBusPath start(final Mode mode) {
         return start(mode.getValue());
     }
 
-    public Path start(final String mode) {
+    public DBusPath start(final String mode) {
         return manager.startUnit(name, mode);
     }
 
-    public Path stop(final Mode mode) {
+    public DBusPath stop(final Mode mode) {
         return stop(mode.getValue());
     }
 
-    public Path stop(final String mode) {
+    public DBusPath stop(final String mode) {
         return manager.stopUnit(name, mode);
     }
 
-    public Path reload(final Mode mode) {
+    public DBusPath reload(final Mode mode) {
         return reload(mode.getValue());
     }
 
-    public Path reload(final String mode) {
+    public DBusPath reload(final String mode) {
         return manager.reloadUnit(name, mode);
     }
 
-    public Path restart(final Mode mode) {
+    public DBusPath restart(final Mode mode) {
         return restart(mode.getValue());
     }
 
-    public Path restart(final String mode) {
+    public DBusPath restart(final String mode) {
         return manager.restartUnit(name, mode);
     }
 
-    public Path tryRestart(final Mode mode) {
+    public DBusPath tryRestart(final Mode mode) {
         return tryRestart(mode.getValue());
     }
 
-    public Path tryRestart(final String mode) {
+    public DBusPath tryRestart(final String mode) {
         return manager.tryRestartUnit(name, mode);
     }
 
-    public Path reloadOrRestart(final Mode mode) {
+    public DBusPath reloadOrRestart(final Mode mode) {
         return reloadOrRestart(mode.getValue());
     }
 
-    public Path reloadOrRestart(final String mode) {
+    public DBusPath reloadOrRestart(final String mode) {
         return manager.reloadOrRestartUnit(name, mode);
     }
 
-    public Path reloadOrTryRestart(final Mode mode) {
+    public DBusPath reloadOrTryRestart(final Mode mode) {
         return reloadOrTryRestart(mode.getValue());
     }
 
-    public Path reloadOrTryRestart(final String mode) {
+    public DBusPath reloadOrTryRestart(final String mode) {
         return manager.reloadOrTryRestartUnit(name, mode);
     }
 

--- a/src/main/java/de/thjom/java/systemd/UnitMonitor.java
+++ b/src/main/java/de/thjom/java/systemd/UnitMonitor.java
@@ -11,10 +11,6 @@
 
 package de.thjom.java.systemd;
 
-import static de.thjom.java.systemd.Unit.Property.ACTIVE_STATE;
-import static de.thjom.java.systemd.Unit.Property.LOAD_STATE;
-import static de.thjom.java.systemd.Unit.Property.SUB_STATE;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -26,11 +22,11 @@ import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import org.freedesktop.DBus.Properties.PropertiesChanged;
-import org.freedesktop.dbus.DBusSigHandler;
-import org.freedesktop.dbus.DBusSignal;
-import org.freedesktop.dbus.Variant;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusSigHandler;
+import org.freedesktop.dbus.interfaces.Properties.PropertiesChanged;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.freedesktop.dbus.types.Variant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +36,10 @@ import de.thjom.java.systemd.interfaces.ManagerInterface.UnitFilesChanged;
 abstract class UnitMonitor extends AbstractAdapter implements UnitStateNotifier {
 
     protected static final String ERROR_MSG_MONITOR_REFRESH = "Error while refreshing internal monitor state";
+
+	private static final Object ACTIVE_STATE = "active";
+	private static final Object LOAD_STATE = "loaded";
+	private static final Object SUB_STATE = "running";
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -89,8 +89,7 @@ abstract class UnitMonitor extends AbstractAdapter implements UnitStateNotifier 
             Optional<Unit> unit = getMonitoredUnit(Unit.extractName(s.getPath()));
 
             if (unit.isPresent()) {
-                Map<String, Variant<?>> properties = s.changedProperties;
-
+                Map<String, Variant<?>> properties = s.getPropertiesChanged();
                 if (properties.containsKey(ACTIVE_STATE) || properties.containsKey(LOAD_STATE) || properties.containsKey(SUB_STATE)) {
                     synchronized (unitStateListeners) {
                         unitStateListeners.forEach(l -> l.stateChanged(unit.get(), properties));

--- a/src/main/java/de/thjom/java/systemd/UnitStateListener.java
+++ b/src/main/java/de/thjom/java/systemd/UnitStateListener.java
@@ -13,7 +13,7 @@ package de.thjom.java.systemd;
 
 import java.util.Map;
 
-import org.freedesktop.dbus.Variant;
+import org.freedesktop.dbus.types.Variant;
 
 @FunctionalInterface
 public interface UnitStateListener {

--- a/src/main/java/de/thjom/java/systemd/interfaces/AutomountInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/AutomountInterface.java
@@ -11,7 +11,7 @@
 
 package de.thjom.java.systemd.interfaces;
 
-import org.freedesktop.dbus.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
 
 @DBusInterfaceName(value = de.thjom.java.systemd.Automount.SERVICE_NAME)
 public interface AutomountInterface extends UnitInterface {

--- a/src/main/java/de/thjom/java/systemd/interfaces/BusNameInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/BusNameInterface.java
@@ -11,7 +11,7 @@
 
 package de.thjom.java.systemd.interfaces;
 
-import org.freedesktop.dbus.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
 
 @DBusInterfaceName(value = de.thjom.java.systemd.BusName.SERVICE_NAME)
 public interface BusNameInterface extends UnitInterface {

--- a/src/main/java/de/thjom/java/systemd/interfaces/DeviceInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/DeviceInterface.java
@@ -11,7 +11,7 @@
 
 package de.thjom.java.systemd.interfaces;
 
-import org.freedesktop.dbus.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
 
 @DBusInterfaceName(value = de.thjom.java.systemd.Device.SERVICE_NAME)
 public interface DeviceInterface extends UnitInterface {

--- a/src/main/java/de/thjom/java/systemd/interfaces/ManagerInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/ManagerInterface.java
@@ -13,11 +13,11 @@ package de.thjom.java.systemd.interfaces;
 
 import java.util.List;
 
-import org.freedesktop.dbus.DBusInterface;
-import org.freedesktop.dbus.DBusInterfaceName;
-import org.freedesktop.dbus.DBusMemberName;
-import org.freedesktop.dbus.Path;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusMemberName;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
 
 import de.thjom.java.systemd.Signal;
 import de.thjom.java.systemd.types.UnitFileType;
@@ -42,7 +42,7 @@ public interface ManagerInterface extends DBusInterface {
     String getDefaultTarget();
 
     @DBusMemberName(value = "GetUnitByPID")
-    Path getUnitByPID(int pid);
+    DBusPath getUnitByPID(int pid);
 
     @DBusMemberName(value = "Halt")
     void halt();
@@ -60,7 +60,7 @@ public interface ManagerInterface extends DBusInterface {
     List<UnitType> listUnits();
 
     @DBusMemberName(value = "LoadUnit")
-    Path loadUnit(String name);
+    DBusPath loadUnit(String name);
 
     @DBusMemberName(value = "LookupDynamicUserByName")
     long lookupDynamicUserByName(String name);
@@ -84,13 +84,13 @@ public interface ManagerInterface extends DBusInterface {
     void reload();
 
     @DBusMemberName(value = "ReloadOrRestartUnit")
-    Path reloadOrRestartUnit(String name, String mode);
+    DBusPath reloadOrRestartUnit(String name, String mode);
 
     @DBusMemberName(value = "ReloadOrTryRestartUnit")
-    Path reloadOrTryRestartUnit(String name, String mode);
+    DBusPath reloadOrTryRestartUnit(String name, String mode);
 
     @DBusMemberName(value = "ReloadUnit")
-    Path reloadUnit(String name, String mode);
+    DBusPath reloadUnit(String name, String mode);
 
     @DBusMemberName(value = "ResetFailed")
     void resetFailed();
@@ -99,7 +99,7 @@ public interface ManagerInterface extends DBusInterface {
     void resetFailedUnit(String name);
 
     @DBusMemberName(value = "RestartUnit")
-    Path restartUnit(String name, String mode);
+    DBusPath restartUnit(String name, String mode);
 
     @DBusMemberName(value = "SetEnvironment")
     void setEnvironment(String name);
@@ -108,10 +108,10 @@ public interface ManagerInterface extends DBusInterface {
     void setExitCode(byte value);
 
     @DBusMemberName(value = "StartUnit")
-    Path startUnit(String name, String mode);
+    DBusPath startUnit(String name, String mode);
 
     @DBusMemberName(value = "StopUnit")
-    Path stopUnit(String name, String mode);
+    DBusPath stopUnit(String name, String mode);
 
     @DBusMemberName(value = "Subscribe")
     void subscribe();
@@ -120,7 +120,7 @@ public interface ManagerInterface extends DBusInterface {
     void switchRoot(String newRoot, String init);
 
     @DBusMemberName(value = "TryRestartUnit")
-    Path tryRestartUnit(String name, String mode);
+    DBusPath tryRestartUnit(String name, String mode);
 
     @DBusMemberName(value = "UnrefUnit")
     void unrefUnit(String name);
@@ -136,7 +136,7 @@ public interface ManagerInterface extends DBusInterface {
 
     class JobNew extends Signal {
 
-        public JobNew(String objectPath, long id, Path job, String unit) throws DBusException {
+        public JobNew(String objectPath, long id, DBusPath job, String unit) throws DBusException {
             super(objectPath, id, job, unit);
         }
 
@@ -144,7 +144,7 @@ public interface ManagerInterface extends DBusInterface {
             return getParameter(0, 0L);
         }
 
-        public Path getJob() {
+        public DBusPath getJob() {
             return getParameter(1, null);
         }
 
@@ -156,7 +156,7 @@ public interface ManagerInterface extends DBusInterface {
 
     class JobRemoved extends Signal {
 
-        public JobRemoved(String objectPath, long id, Path job, String unit, String result) throws DBusException {
+        public JobRemoved(String objectPath, long id, DBusPath job, String unit, String result) throws DBusException {
             super(objectPath, id, job, unit, result);
         }
 
@@ -164,7 +164,7 @@ public interface ManagerInterface extends DBusInterface {
             return getParameter(0, 0L);
         }
 
-        public Path getJob() {
+        public DBusPath getJob() {
             return getParameter(1, null);
         }
 
@@ -233,7 +233,7 @@ public interface ManagerInterface extends DBusInterface {
 
     class UnitNew extends Signal {
 
-        public UnitNew(String objectPath, String id, Path unit) throws DBusException {
+        public UnitNew(String objectPath, String id, DBusPath unit) throws DBusException {
             super(objectPath, id, unit);
         }
 
@@ -241,7 +241,7 @@ public interface ManagerInterface extends DBusInterface {
             return getParameter(0, "");
         }
 
-        public Path getUnit() {
+        public DBusPath getUnit() {
             return getParameter(1, null);
         }
 
@@ -249,7 +249,7 @@ public interface ManagerInterface extends DBusInterface {
 
     class UnitRemoved extends Signal {
 
-        public UnitRemoved(String objectPath, String id, Path unit) throws DBusException {
+        public UnitRemoved(String objectPath, String id, DBusPath unit) throws DBusException {
             super(objectPath, id, unit);
         }
 
@@ -257,7 +257,7 @@ public interface ManagerInterface extends DBusInterface {
             return getParameter(0, "");
         }
 
-        public Path getUnit() {
+        public DBusPath getUnit() {
             return getParameter(1, null);
         }
 

--- a/src/main/java/de/thjom/java/systemd/interfaces/MountInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/MountInterface.java
@@ -13,8 +13,8 @@ package de.thjom.java.systemd.interfaces;
 
 import java.util.List;
 
-import org.freedesktop.dbus.DBusInterfaceName;
-import org.freedesktop.dbus.DBusMemberName;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusMemberName;
 
 import de.thjom.java.systemd.types.UnitProcessType;
 

--- a/src/main/java/de/thjom/java/systemd/interfaces/PathInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/PathInterface.java
@@ -11,7 +11,7 @@
 
 package de.thjom.java.systemd.interfaces;
 
-import org.freedesktop.dbus.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
 
 @DBusInterfaceName(value = de.thjom.java.systemd.Path.SERVICE_NAME)
 public interface PathInterface extends UnitInterface {

--- a/src/main/java/de/thjom/java/systemd/interfaces/PropertyInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/PropertyInterface.java
@@ -11,10 +11,10 @@
 
 package de.thjom.java.systemd.interfaces;
 
-import org.freedesktop.dbus.DBusInterface;
-import org.freedesktop.dbus.DBusInterfaceName;
-import org.freedesktop.dbus.DBusMemberName;
-import org.freedesktop.dbus.Variant;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusMemberName;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.types.Variant;
 
 @DBusInterfaceName(value = de.thjom.java.systemd.Properties.SERVICE_NAME)
 public interface PropertyInterface extends DBusInterface {

--- a/src/main/java/de/thjom/java/systemd/interfaces/ScopeInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/ScopeInterface.java
@@ -13,8 +13,8 @@ package de.thjom.java.systemd.interfaces;
 
 import java.util.List;
 
-import org.freedesktop.dbus.DBusInterfaceName;
-import org.freedesktop.dbus.DBusMemberName;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusMemberName;
 import org.freedesktop.dbus.exceptions.DBusException;
 
 import de.thjom.java.systemd.Signal;

--- a/src/main/java/de/thjom/java/systemd/interfaces/ServiceInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/ServiceInterface.java
@@ -13,8 +13,8 @@ package de.thjom.java.systemd.interfaces;
 
 import java.util.List;
 
-import org.freedesktop.dbus.DBusInterfaceName;
-import org.freedesktop.dbus.DBusMemberName;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusMemberName;
 
 import de.thjom.java.systemd.types.UnitProcessType;
 

--- a/src/main/java/de/thjom/java/systemd/interfaces/SliceInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/SliceInterface.java
@@ -13,8 +13,8 @@ package de.thjom.java.systemd.interfaces;
 
 import java.util.List;
 
-import org.freedesktop.dbus.DBusInterfaceName;
-import org.freedesktop.dbus.DBusMemberName;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusMemberName;
 
 import de.thjom.java.systemd.types.UnitProcessType;
 

--- a/src/main/java/de/thjom/java/systemd/interfaces/SnapshotInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/SnapshotInterface.java
@@ -11,8 +11,8 @@
 
 package de.thjom.java.systemd.interfaces;
 
-import org.freedesktop.dbus.DBusInterfaceName;
-import org.freedesktop.dbus.DBusMemberName;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusMemberName;
 
 @DBusInterfaceName(value = de.thjom.java.systemd.Snapshot.SERVICE_NAME)
 public interface SnapshotInterface extends UnitInterface {

--- a/src/main/java/de/thjom/java/systemd/interfaces/SocketInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/SocketInterface.java
@@ -13,8 +13,8 @@ package de.thjom.java.systemd.interfaces;
 
 import java.util.List;
 
-import org.freedesktop.dbus.DBusInterfaceName;
-import org.freedesktop.dbus.DBusMemberName;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusMemberName;
 
 import de.thjom.java.systemd.types.UnitProcessType;
 

--- a/src/main/java/de/thjom/java/systemd/interfaces/SwapInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/SwapInterface.java
@@ -13,8 +13,8 @@ package de.thjom.java.systemd.interfaces;
 
 import java.util.List;
 
-import org.freedesktop.dbus.DBusInterfaceName;
-import org.freedesktop.dbus.DBusMemberName;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusMemberName;
 
 import de.thjom.java.systemd.types.UnitProcessType;
 

--- a/src/main/java/de/thjom/java/systemd/interfaces/TargetInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/TargetInterface.java
@@ -11,7 +11,7 @@
 
 package de.thjom.java.systemd.interfaces;
 
-import org.freedesktop.dbus.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
 
 @DBusInterfaceName(value = de.thjom.java.systemd.Target.SERVICE_NAME)
 public interface TargetInterface extends UnitInterface {

--- a/src/main/java/de/thjom/java/systemd/interfaces/TimerInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/TimerInterface.java
@@ -11,7 +11,7 @@
 
 package de.thjom.java.systemd.interfaces;
 
-import org.freedesktop.dbus.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
 
 @DBusInterfaceName(value = de.thjom.java.systemd.Timer.SERVICE_NAME)
 public interface TimerInterface extends UnitInterface {

--- a/src/main/java/de/thjom/java/systemd/interfaces/UnitInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/UnitInterface.java
@@ -11,34 +11,34 @@
 
 package de.thjom.java.systemd.interfaces;
 
-import org.freedesktop.dbus.DBusInterface;
-import org.freedesktop.dbus.DBusInterfaceName;
-import org.freedesktop.dbus.DBusMemberName;
-import org.freedesktop.dbus.Path;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusMemberName;
+import org.freedesktop.dbus.interfaces.DBusInterface;
 
 @DBusInterfaceName(value = de.thjom.java.systemd.Unit.SERVICE_NAME)
 public interface UnitInterface extends DBusInterface {
 
     @DBusMemberName(value = "Start")
-    Path start(String mode);
+    DBusPath start(String mode);
 
     @DBusMemberName(value = "Stop")
-    Path stop(String mode);
+    DBusPath stop(String mode);
 
     @DBusMemberName(value = "Reload")
-    Path reload(String mode);
+    DBusPath reload(String mode);
 
     @DBusMemberName(value = "Restart")
-    Path restart(String mode);
+    DBusPath restart(String mode);
 
     @DBusMemberName(value = "TryRestart")
-    Path tryRestart(String mode);
+    DBusPath tryRestart(String mode);
 
     @DBusMemberName(value = "ReloadOrRestart")
-    Path reloadOrRestart(String mode);
+    DBusPath reloadOrRestart(String mode);
 
     @DBusMemberName(value = "ReloadOrTryRestart")
-    Path reloadOrTryRestart(String mode);
+    DBusPath reloadOrTryRestart(String mode);
 
     @DBusMemberName(value = "Kill")
     void kill(String who, int signal);

--- a/src/main/java/de/thjom/java/systemd/types/BindPath.java
+++ b/src/main/java/de/thjom/java/systemd/types/BindPath.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.dbus.UInt64;
+import org.freedesktop.dbus.types.UInt64;
 
 public class BindPath {
 

--- a/src/main/java/de/thjom/java/systemd/types/ExecutionInfo.java
+++ b/src/main/java/de/thjom/java/systemd/types/ExecutionInfo.java
@@ -15,8 +15,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.dbus.UInt32;
-import org.freedesktop.dbus.UInt64;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.UInt64;
 
 public class ExecutionInfo {
 

--- a/src/main/java/de/thjom/java/systemd/types/IOBandwidth.java
+++ b/src/main/java/de/thjom/java/systemd/types/IOBandwidth.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.dbus.UInt64;
+import org.freedesktop.dbus.types.UInt64;
 
 public class IOBandwidth extends IOPath {
 

--- a/src/main/java/de/thjom/java/systemd/types/IODeviceWeight.java
+++ b/src/main/java/de/thjom/java/systemd/types/IODeviceWeight.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.dbus.UInt64;
+import org.freedesktop.dbus.types.UInt64;
 
 public class IODeviceWeight extends IOPath {
 

--- a/src/main/java/de/thjom/java/systemd/types/IOIops.java
+++ b/src/main/java/de/thjom/java/systemd/types/IOIops.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.dbus.UInt64;
+import org.freedesktop.dbus.types.UInt64;
 
 public class IOIops extends IOPath {
 

--- a/src/main/java/de/thjom/java/systemd/types/IpAddressPolicy.java
+++ b/src/main/java/de/thjom/java/systemd/types/IpAddressPolicy.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.dbus.UInt32;
+import org.freedesktop.dbus.types.UInt32;
 
 public class IpAddressPolicy {
 

--- a/src/main/java/de/thjom/java/systemd/types/Job.java
+++ b/src/main/java/de/thjom/java/systemd/types/Job.java
@@ -11,24 +11,25 @@
 
 package de.thjom.java.systemd.types;
 
-import org.freedesktop.dbus.Path;
-import org.freedesktop.dbus.UInt32;
+
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.types.UInt32;
 
 public class Job {
 
     private final long id;
-    private final Path objectPath;
+    private final DBusPath objectPath; 
 
     public Job(final Object[] array) {
         this.id = ((UInt32) array[0]).longValue();
-        this.objectPath = (Path) array[1];
+        this.objectPath = (DBusPath) array[1];
     }
 
     public long getId() {
         return id;
     }
 
-    public Path getObjectPath() {
+    public DBusPath getObjectPath() {
         return objectPath;
     }
 

--- a/src/main/java/de/thjom/java/systemd/types/TimersCalendar.java
+++ b/src/main/java/de/thjom/java/systemd/types/TimersCalendar.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.dbus.UInt64;
+import org.freedesktop.dbus.types.UInt64;
 
 public class TimersCalendar {
 

--- a/src/main/java/de/thjom/java/systemd/types/TimersMonotonic.java
+++ b/src/main/java/de/thjom/java/systemd/types/TimersMonotonic.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.dbus.UInt64;
+import org.freedesktop.dbus.types.UInt64;
 
 public class TimersMonotonic {
 

--- a/src/main/java/de/thjom/java/systemd/types/UnitFileType.java
+++ b/src/main/java/de/thjom/java/systemd/types/UnitFileType.java
@@ -11,7 +11,7 @@
 
 package de.thjom.java.systemd.types;
 
-import org.freedesktop.dbus.Position;
+import org.freedesktop.dbus.annotations.Position;
 
 public class UnitFileType extends UnitBase implements Comparable<UnitFileType> {
 

--- a/src/main/java/de/thjom/java/systemd/types/UnitProcessType.java
+++ b/src/main/java/de/thjom/java/systemd/types/UnitProcessType.java
@@ -11,9 +11,9 @@
 
 package de.thjom.java.systemd.types;
 
-import org.freedesktop.dbus.Position;
 import org.freedesktop.dbus.Struct;
-import org.freedesktop.dbus.UInt32;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.UInt32;
 
 public class UnitProcessType extends Struct implements Comparable<UnitProcessType> {
 

--- a/src/main/java/de/thjom/java/systemd/types/UnitType.java
+++ b/src/main/java/de/thjom/java/systemd/types/UnitType.java
@@ -11,9 +11,10 @@
 
 package de.thjom.java.systemd.types;
 
-import org.freedesktop.dbus.Path;
-import org.freedesktop.dbus.Position;
-import org.freedesktop.dbus.UInt32;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.UInt32;
+
 
 public class UnitType extends UnitBase implements Comparable<UnitType> {
 
@@ -36,7 +37,7 @@ public class UnitType extends UnitBase implements Comparable<UnitType> {
     private final String followingUnit;
 
     @Position(6)
-    private final Path unitObjectPath;
+    private final DBusPath unitObjectPath;
 
     @Position(7)
     private final int jobId;
@@ -45,11 +46,11 @@ public class UnitType extends UnitBase implements Comparable<UnitType> {
     private final String jobType;
 
     @Position(9)
-    private final Path jobObjectPath;
+    private final DBusPath jobObjectPath;
 
     public UnitType(final String unitName, final String unitDescription, final String loadState,
-            final String activeState, final String subState, final String followingUnit, final Path unitObjectPath,
-            final UInt32 jobId, String jobType, final Path jobObjectPath) {
+            final String activeState, final String subState, final String followingUnit, final DBusPath unitObjectPath,
+            final UInt32 jobId, String jobType, final DBusPath jobObjectPath) {
         super(unitName);
 
         this.unitName = unitName;
@@ -106,7 +107,7 @@ public class UnitType extends UnitBase implements Comparable<UnitType> {
         return followingUnit;
     }
 
-    public Path getUnitObjectPath() {
+    public DBusPath getUnitObjectPath() {
         return unitObjectPath;
     }
 
@@ -118,7 +119,7 @@ public class UnitType extends UnitBase implements Comparable<UnitType> {
         return jobType;
     }
 
-    public Path getJobObjectPath() {
+    public DBusPath getJobObjectPath() {
         return jobObjectPath;
     }
 

--- a/src/test/java/de/thjom/java/systemd/AbstractTestCase.java
+++ b/src/test/java/de/thjom/java/systemd/AbstractTestCase.java
@@ -17,10 +17,10 @@ import java.lang.reflect.Type;
 import java.math.BigInteger;
 import java.util.Vector;
 
-import org.freedesktop.dbus.DBusConnection;
-import org.freedesktop.dbus.UInt64;
-import org.freedesktop.dbus.Variant;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.types.UInt64;
+import org.freedesktop.dbus.types.Variant;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;

--- a/src/test/java/de/thjom/java/systemd/SignalSequencerTest.java
+++ b/src/test/java/de/thjom/java/systemd/SignalSequencerTest.java
@@ -19,9 +19,9 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import org.freedesktop.dbus.DBusInterface;
-import org.freedesktop.dbus.DBusSignal;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.messages.DBusSignal;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -186,7 +186,7 @@ public class SignalSequencerTest implements DBusInterface {
         public TestSignal(final long serial) throws DBusException {
             super(Systemd.OBJECT_PATH);
 
-            this.serial = serial;
+            this.setSerial(serial);
         }
 
         @Override

--- a/src/test/java/de/thjom/java/systemd/UnitMonitorTest.java
+++ b/src/test/java/de/thjom/java/systemd/UnitMonitorTest.java
@@ -17,11 +17,10 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.awaitility.Awaitility;
-import org.freedesktop.DBus;
-import org.freedesktop.DBus.Properties.PropertiesChanged;
-import org.freedesktop.dbus.DBusSigHandler;
-import org.freedesktop.dbus.Variant;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusSigHandler;
+import org.freedesktop.dbus.interfaces.Properties.PropertiesChanged;
+import org.freedesktop.dbus.types.Variant;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -56,7 +55,7 @@ public class UnitMonitorTest extends AbstractTestCase {
             };
 
             // Test handler addition and removal
-            DBusSigHandler<PropertiesChanged> handler = new DBusSigHandler<DBus.Properties.PropertiesChanged>() {
+            DBusSigHandler<PropertiesChanged> handler = new DBusSigHandler<PropertiesChanged>() {
 
                 @Override
                 public void handle(PropertiesChanged s) {

--- a/src/test/java/de/thjom/java/systemd/UnitNameMonitorTest.java
+++ b/src/test/java/de/thjom/java/systemd/UnitNameMonitorTest.java
@@ -11,8 +11,8 @@
 
 package de.thjom.java.systemd;
 
-import org.freedesktop.dbus.Variant;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.types.Variant;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;

--- a/src/test/java/de/thjom/java/systemd/UnitTypeMonitorTest.java
+++ b/src/test/java/de/thjom/java/systemd/UnitTypeMonitorTest.java
@@ -14,9 +14,9 @@ package de.thjom.java.systemd;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.freedesktop.dbus.UInt32;
-import org.freedesktop.dbus.Variant;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;

--- a/src/test/java/de/thjom/java/systemd/types/ExecutionInfoTest.java
+++ b/src/test/java/de/thjom/java/systemd/types/ExecutionInfoTest.java
@@ -15,8 +15,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.dbus.UInt32;
-import org.freedesktop.dbus.UInt64;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.UInt64;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/src/test/java/de/thjom/java/systemd/types/IOBandwidthTest.java
+++ b/src/test/java/de/thjom/java/systemd/types/IOBandwidthTest.java
@@ -15,7 +15,7 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.dbus.UInt64;
+import org.freedesktop.dbus.types.UInt64;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/src/test/java/de/thjom/java/systemd/types/IODeviceWeightTest.java
+++ b/src/test/java/de/thjom/java/systemd/types/IODeviceWeightTest.java
@@ -15,7 +15,7 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.dbus.UInt64;
+import org.freedesktop.dbus.types.UInt64;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/src/test/java/de/thjom/java/systemd/types/IOIopsTest.java
+++ b/src/test/java/de/thjom/java/systemd/types/IOIopsTest.java
@@ -15,7 +15,7 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.dbus.UInt64;
+import org.freedesktop.dbus.types.UInt64;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/src/test/java/de/thjom/java/systemd/types/JobTest.java
+++ b/src/test/java/de/thjom/java/systemd/types/JobTest.java
@@ -11,16 +11,17 @@
 
 package de.thjom.java.systemd.types;
 
-import org.freedesktop.dbus.Path;
-import org.freedesktop.dbus.UInt32;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.types.UInt32;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class JobTest {
 
     @Test(description="Tests parameterized constructor.")
-    public void testConstructor() {
-        Path path = new Path("foo");
+    public void testConstructor() throws DBusException {
+        DBusPath path = new DBusPath("foo");
 
         Job instance = new Job(new Object[] { new UInt32("1234"), path });
 

--- a/src/test/java/de/thjom/java/systemd/types/TimersCalendarTest.java
+++ b/src/test/java/de/thjom/java/systemd/types/TimersCalendarTest.java
@@ -14,7 +14,7 @@ package de.thjom.java.systemd.types;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.dbus.UInt64;
+import org.freedesktop.dbus.types.UInt64;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/src/test/java/de/thjom/java/systemd/types/TimersMonotonicTest.java
+++ b/src/test/java/de/thjom/java/systemd/types/TimersMonotonicTest.java
@@ -15,7 +15,7 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Vector;
 
-import org.freedesktop.dbus.UInt64;
+import org.freedesktop.dbus.types.UInt64;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/src/test/java/de/thjom/java/systemd/types/UnitTypeTest.java
+++ b/src/test/java/de/thjom/java/systemd/types/UnitTypeTest.java
@@ -15,8 +15,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.freedesktop.dbus.Path;
-import org.freedesktop.dbus.UInt32;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.types.UInt32;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -32,8 +32,8 @@ public class UnitTypeTest {
         UnitType type = new UnitType(unitName, "Dummy unit",
                                      "loaded", "active", "running",
                                      "Follow",
-                                     new Path(Unit.OBJECT_PATH + Systemd.escapePath(unitName)),
-                                     new UInt32(42L), "dummy type", new Path("dummy_path"));
+                                     new DBusPath(Unit.OBJECT_PATH + Systemd.escapePath(unitName)),
+                                     new UInt32(42L), "dummy type", new DBusPath("dummy_path"));
 
         Assert.assertEquals(type.getUnitName(), unitName);
         Assert.assertEquals(type.getUnitDescription(), "Dummy unit");
@@ -54,8 +54,8 @@ public class UnitTypeTest {
         UnitType type = new UnitType(unitName, "Dummy unit",
                 "loaded", "active", "running",
                 "Follow",
-                new Path(Unit.OBJECT_PATH + Systemd.escapePath(unitName)),
-                new UInt32(42L), "dummy type", new Path("dummy_path"));
+                new DBusPath(Unit.OBJECT_PATH + Systemd.escapePath(unitName)),
+                new UInt32(42L), "dummy type", new DBusPath("dummy_path"));
 
         Assert.assertFalse(type.getSummary().isEmpty());
     }
@@ -67,16 +67,16 @@ public class UnitTypeTest {
         UnitType type1 = new UnitType(unitName1, "Dummy unit",
                 "loaded", "active", "running",
                 "Follow",
-                new Path(Unit.OBJECT_PATH + Systemd.escapePath(unitName1)),
-                new UInt32(42L), "dummy type", new Path("dummy_path"));
+                new DBusPath(Unit.OBJECT_PATH + Systemd.escapePath(unitName1)),
+                new UInt32(42L), "dummy type", new DBusPath("dummy_path"));
 
         String unitName2 = "dummy2.service";
 
         UnitType type2 = new UnitType(unitName2, "Dummy unit",
                 "loaded", "active", "running",
                 "Follow",
-                new Path(Unit.OBJECT_PATH + Systemd.escapePath(unitName2)),
-                new UInt32(42L), "dummy type", new Path("dummy_path"));
+                new DBusPath(Unit.OBJECT_PATH + Systemd.escapePath(unitName2)),
+                new UInt32(42L), "dummy type", new DBusPath("dummy_path"));
 
         // Test list sorting
         List<UnitType> list = new ArrayList<>();


### PR DESCRIPTION
This is mainly changes in import packages and one or two class names (e.g. DBusPath instead of Path) to make java-systemd compatible with dbus-java version 3.2.1 and above.

I have been unable to run the test suite for this, the error it produces appears some general problem with tests, as it also occurs without this patch present.