### PR TITLE
Modularise as de.thjom.java.systemd, update to final dbus-java 3.3.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 	<dependency>
 	  <groupId>com.github.hypfvieh</groupId>
 	  <artifactId>dbus-java</artifactId>
-	  <version>3.2.4</version>
+	  <version>3.3.0</version>
 	</dependency>
 	<dependency>
       <groupId>javax.xml.bind</groupId>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module de.thjom.java.systemd {
+	requires transitive org.freedesktop.dbus;
+	requires transitive java.xml.bind;
+	exports de.thjom.java.systemd.features;
+	exports de.thjom.java.systemd.interfaces;
+	exports de.thjom.java.systemd.types;
+	exports de.thjom.java.systemd;
+}


### PR DESCRIPTION
dbus-java 3.3.0 is out and compatible with [JPMS](https://openjdk.java.net/projects/jigsaw/spec/), so this PR adds module-info to java-systemd to make it compatible too. I see you have updated the Java requirement to 11, so there is no need to make this an [MRJAR](https://openjdk.java.net/jeps/238). 