### PR TITLE
Working in ability to enable and disable units

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.github.thjomnx</groupId>
   <artifactId>java-systemd</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.2.0-eks</version>
   <packaging>jar</packaging>
 
   <name>${project.artifactId}</name>
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>com.github.hypfvieh</groupId>
       <artifactId>dbus-java</artifactId>
-      <version>3.3.0</version>
+      <version>3.3.1</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
@@ -57,29 +57,29 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
+      <version>1.7.36</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.30</version>
+      <version>1.7.36</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>7.4.0</version>
+      <version>7.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>3.8.0</version>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>4.0.3</version>
+      <version>4.2.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/de/thjom/java/systemd/Manager.java
+++ b/src/main/java/de/thjom/java/systemd/Manager.java
@@ -11,23 +11,24 @@
 
 package de.thjom.java.systemd;
 
-import java.math.BigInteger;
-import java.util.List;
-
-import org.freedesktop.dbus.DBusPath;
-import org.freedesktop.dbus.connections.impl.DBusConnection;
-import org.freedesktop.dbus.exceptions.DBusException;
-import org.freedesktop.dbus.interfaces.Introspectable;
-
 import de.thjom.java.systemd.Unit.Mode;
 import de.thjom.java.systemd.Unit.Who;
 import de.thjom.java.systemd.interfaces.ManagerInterface;
 import de.thjom.java.systemd.types.DynamicUser;
+import de.thjom.java.systemd.types.Pair;
+import de.thjom.java.systemd.types.StructForUnitEnableAndDisable;
 import de.thjom.java.systemd.types.UnitFileChange;
 import de.thjom.java.systemd.types.UnitFileInstallChange;
 import de.thjom.java.systemd.types.UnitFileType;
 import de.thjom.java.systemd.types.UnitProcessType;
 import de.thjom.java.systemd.types.UnitType;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.Introspectable;
+
+import java.math.BigInteger;
+import java.util.List;
 
 public class Manager extends InterfaceAdapter {
 
@@ -195,7 +196,7 @@ public class Manager extends InterfaceAdapter {
         getInterface().clearJobs();
     }
 
-    public List<UnitFileChange> disableUnitFiles(final List<String> names, final boolean runtime) {
+    public List<StructForUnitEnableAndDisable> disableUnitFiles(final List<String> names, final boolean runtime) {
         return getInterface().disableUnitFiles(names, runtime);
     }
 
@@ -203,7 +204,7 @@ public class Manager extends InterfaceAdapter {
         return getInterface().dump();
     }
 
-    public List<UnitFileChange> enableUnitFiles(final List<String> names, final boolean runtime, final boolean force) {
+    public Pair<Boolean, List<StructForUnitEnableAndDisable>> enableUnitFiles(final List<String> names, final boolean runtime, final boolean force) {
         return getInterface().enableUnitFiles(names, runtime, force);
     }
 
@@ -355,7 +356,7 @@ public class Manager extends InterfaceAdapter {
         return getInterface().restartUnit(name, mode);
     }
 
-    public List<UnitFileChange> revertUnitFiles(final List<String> names){
+    public List<UnitFileChange> revertUnitFiles(final List<String> names) {
         return getInterface().revertUnitFiles(names);
     }
 

--- a/src/main/java/de/thjom/java/systemd/interfaces/ManagerInterface.java
+++ b/src/main/java/de/thjom/java/systemd/interfaces/ManagerInterface.java
@@ -11,7 +11,9 @@
 
 package de.thjom.java.systemd.interfaces;
 
+import de.thjom.java.systemd.types.Pair;
 import de.thjom.java.systemd.Signal;
+import de.thjom.java.systemd.types.StructForUnitEnableAndDisable;
 import de.thjom.java.systemd.types.*;
 import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.annotations.DBusInterfaceName;
@@ -37,13 +39,13 @@ public interface ManagerInterface extends DBusInterface {
     void clearJobs();
 
     @DBusMemberName(value = "DisableUnitFiles")
-    List<UnitFileChange> disableUnitFiles(List<String> names, boolean runtime);
+    List<StructForUnitEnableAndDisable> disableUnitFiles(List<String> names, boolean runtime);
 
     @DBusMemberName(value = "Dump")
     String dump();
 
     @DBusMemberName(value = "EnableUnitFiles")
-    List<UnitFileChange> enableUnitFiles(List<String> names, boolean runtime, boolean force);
+    Pair<Boolean, List<StructForUnitEnableAndDisable>> enableUnitFiles(List<String> names, boolean runtime, boolean force);
 
     @DBusMemberName(value = "Exit")
     void exit();

--- a/src/main/java/de/thjom/java/systemd/types/Pair.java
+++ b/src/main/java/de/thjom/java/systemd/types/Pair.java
@@ -1,0 +1,28 @@
+/*
+ * Java-systemd implementation
+ * Copyright (c) 2016 Markus Enax
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of either the GNU Lesser General Public License Version 2 or the
+ * Academic Free Licence Version 3.0.
+ *
+ * Full licence texts are included in the COPYING file with this program.
+ */
+
+package de.thjom.java.systemd.types;
+
+import org.freedesktop.dbus.Tuple;
+import org.freedesktop.dbus.annotations.Position;
+
+public final class Pair<A, B> extends Tuple {
+
+    @Position(0)
+    public final A a;
+    @Position(1)
+    public final B b;
+
+    public Pair(A a, B b) {
+        this.a = a;
+        this.b = b;
+    }
+}

--- a/src/main/java/de/thjom/java/systemd/types/StructForUnitEnableAndDisable.java
+++ b/src/main/java/de/thjom/java/systemd/types/StructForUnitEnableAndDisable.java
@@ -1,0 +1,30 @@
+/*
+ * Java-systemd implementation
+ * Copyright (c) 2016 Markus Enax
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of either the GNU Lesser General Public License Version 2 or the
+ * Academic Free Licence Version 3.0.
+ *
+ * Full licence texts are included in the COPYING file with this program.
+ */
+
+package de.thjom.java.systemd.types;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+
+public final class StructForUnitEnableAndDisable extends Struct {
+    @Position(0)
+    public final String a;
+    @Position(1)
+    public final String b;
+    @Position(2)
+    public final String c;
+
+    public StructForUnitEnableAndDisable(String a, String b, String c) {
+        this.a = a;
+        this.b = b;
+        this.c = c;
+    }
+}


### PR DESCRIPTION
- Introduced a Struct and Pair class as needed by dbus-java
- Updated various versions

I am labeling this version as 2.2.0-eks so if this commit is accepted,
be sure to remove -eks. 

FYI - For now, I needed to remove the `-SNAPSHOT` versioning since I will need to use this version in my system. 

---

In a working state. Needed to also use a special struct class for the disableUnitFiles call (+3 squashed commit)

Squashed commit:

[9dde539] Found that `enableUnitFiles` may perform what I need to get units started.

The `List<UnitFileChange>` is not the proper return type. Some research lead me to AgNO3 project that uses a Tuple type of structure to hold the return type: https://github.com/AgNO3/code/blob/main/orchestrator/agent/system/eu.agno3.orchestrator.system.init.systemd/src/main/java/org/freedesktop/systemd1/Manager.java

Still experimenting...

[7197b50] WIP: TDD and fleshing out unit creation with dbus

[fb4e92d] Starting work towards creating/update/delete units

- Specifically service units for now.
- Using my own version number
- Using lombok to reduce builder code. https://github.com/thjomnx/java-systemd/issues/6#issuecomment-1068341958